### PR TITLE
fix: use correct file extension for Node

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,7 +37,7 @@ export default [
   },
   {
     input: `./src/index.ts`,
-    output: { file: `dist/index.cjs.js`, format: 'cjs' },
+    output: { file: `dist/index.cjs`, format: 'cjs' },
     external,
     plugins: [
       json(),


### PR DESCRIPTION
Fixes discontinuity for Node users with [`package.json`](https://github.com/pmndrs/react-three-flex/blob/master/package.json) linking to `index.cjs` whereas Rollup builds to `index.cjs.js`.