### PR TITLE
disableSizeRecalc option in Flex

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -20,7 +20,7 @@ export function useFlexSize() {
   return size
 }
 
-export function useNode() {
+export function useFlexNode() {
   const { node } = useContext(boxContext)
   return node
 }
@@ -31,7 +31,7 @@ export function useNode() {
  */
 export function useSetSize(): (width: number, height: number) => void {
   const { requestReflow, scaleFactor } = useContext(flexContext)
-  const node = useNode()
+  const node = useFlexNode()
 
   const sync = useCallback(
     (width: number, height: number) => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,5 @@
-import { useContext as useContextImpl } from 'react'
+import { useCallback, useContext as useContextImpl } from 'react'
+import { Mesh, Vector3 } from 'three'
 import { flexContext, boxContext } from './context'
 
 export function useContext<T>(context: React.Context<T>) {
@@ -17,4 +18,58 @@ export function useReflow() {
 export function useFlexSize() {
   const { size } = useContext(boxContext)
   return size
+}
+
+export function useNode() {
+  const { node } = useContext(boxContext)
+  return node
+}
+
+/**
+ * explicitly set the size of the box's yoga node
+ * @requires that the surrounding Flex-Element has `disableSizeRecalc` set to `true`
+ */
+export function useSetSize(): (width: number, height: number) => void {
+  const { requestReflow, scaleFactor } = useContext(flexContext)
+  const node = useNode()
+
+  const sync = useCallback(
+    (width: number, height: number) => {
+      if (node == null) {
+        throw new Error('yoga node is null. sync size is impossible')
+      }
+      node.setWidth(width * scaleFactor)
+      node.setHeight(height * scaleFactor)
+      requestReflow()
+    },
+    [node, requestReflow]
+  )
+
+  return sync
+}
+
+const helperVector = new Vector3()
+
+/**
+ * explicitly sync the yoga node size with a mesh's geometry and uniform global scale
+ * @requires that the surrounding Flex-Element has `disableSizeRecalc` set to `true`
+ */
+export function useSyncGeometrySize(): (mesh: Mesh) => void {
+  const setSize = useSetSize()
+  return useCallback(
+    (mesh: Mesh) => {
+      mesh.updateMatrixWorld()
+      helperVector.setFromMatrixScale(mesh.matrixWorld)
+
+      //since the scale is in global space but the box boundings are in local space, scaling can't be translated, thus a uniform scaling is required to have this work properly
+      if (Math.abs(helperVector.x - helperVector.y) > 0.001 || Math.abs(helperVector.y - helperVector.z) > 0.001) {
+        throw new Error('object was not scaled uniformly')
+      }
+      const worldScale = helperVector.x
+      mesh.geometry.computeBoundingBox()
+      const box = mesh.geometry.boundingBox!
+      setSize((box.max.x - box.min.x) * worldScale, (box.max.y - box.min.y) * worldScale)
+    },
+    [setSize]
+  )
 }


### PR DESCRIPTION
Fixes #48 

Option to disable the automatic calculation of the bounding box, through the Flex-Element.
Allows the developer to talk to the yoga node directly and change the node's size without any rerender from react and gives much more control over the yoga node.

I've also added 3 hooks:
* `useNode`-> get the yoga node
* `useSetSize` -> set the yoga node size explicitly (uses `useNode`)
* `useSyncGeometrySize` -> synchronize the yoga node size with a mesh explicitly (uses `useSetSize`)

`useSetSize` and `useSyncGeometrySize` might be very specific, but `useNode` would be required to make these implementations (since I think the context is not exported).
Having the `useSyncGeometrySize` hook allows to implement sth. like this:

```tsx
import React from "react"
import { useSyncGeometrySize } from "@react-three/flex"
import { Text } from "@react-three/drei"

export function FlexText({ ...props }: React.ComponentProps<typeof Text>) {
    const onSync = useSyncGeometrySize()
    return (
        <Text onSync={onSync} {...props} />
    )
}
```

which would then be used inside a flex & box element:
```tsx
<Flex disableSizeRecalc><Box><FlexText>Hello World!</FlexText></Box></Flex>
```

But as soon as someone uses `disableSizeRecalc` he now has to have every element declare its own size explicitly (which is intended in this case).