### PR TITLE
Added ref forwarding to Flex and Box

### DIFF
--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -2,82 +2,84 @@ import React, { useLayoutEffect, useRef, useMemo, useState } from 'react'
 import * as THREE from 'three'
 import Yoga from 'yoga-layout-prebuilt'
 import { ReactThreeFiber, useFrame } from '@react-three/fiber'
+import mergeRefs from 'react-merge-refs'
 
 import { setYogaProperties, rmUndefFromObj } from './util'
 import { boxContext, flexContext, SharedBoxContext } from './context'
 import { R3FlexProps } from './props'
 import { useReflow, useContext } from './hooks'
 
-/**
- * Box container for 3D Objects.
- * For containing Boxes use `<Flex />`.
- */
-export function Box({
-  // Non-flex props
-  children,
-  centerAnchor,
-
-  // flex props
-  flexDirection,
-  flexDir,
-  dir,
-
-  alignContent,
-  alignItems,
-  alignSelf,
-  align,
-
-  justifyContent,
-  justify,
-
-  flexBasis,
-  basis,
-  flexGrow,
-  grow,
-
-  flexShrink,
-  shrink,
-
-  flexWrap,
-  wrap,
-
-  margin,
-  m,
-  marginBottom,
-  marginLeft,
-  marginRight,
-  marginTop,
-  mb,
-  ml,
-  mr,
-  mt,
-
-  padding,
-  p,
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-  paddingTop,
-  pb,
-  pl,
-  pr,
-  pt,
-
-  height,
-  width,
-
-  maxHeight,
-  maxWidth,
-  minHeight,
-  minWidth,
-
-  // other
-  ...props
-}: {
+export type BoxProps = {
   centerAnchor?: boolean
   children: React.ReactNode | ((width: number, height: number, centerAnchor?: boolean) => React.ReactNode)
 } & R3FlexProps &
-  Omit<ReactThreeFiber.Object3DNode<THREE.Group, typeof THREE.Group>, 'children'>) {
+  Omit<ReactThreeFiber.Object3DNode<THREE.Group, typeof THREE.Group>, 'children'>
+
+function BoxImpl(
+  {
+    // Non-flex props
+    children,
+    centerAnchor,
+
+    // flex props
+    flexDirection,
+    flexDir,
+    dir,
+
+    alignContent,
+    alignItems,
+    alignSelf,
+    align,
+
+    justifyContent,
+    justify,
+
+    flexBasis,
+    basis,
+    flexGrow,
+    grow,
+
+    flexShrink,
+    shrink,
+
+    flexWrap,
+    wrap,
+
+    margin,
+    m,
+    marginBottom,
+    marginLeft,
+    marginRight,
+    marginTop,
+    mb,
+    ml,
+    mr,
+    mt,
+
+    padding,
+    p,
+    paddingBottom,
+    paddingLeft,
+    paddingRight,
+    paddingTop,
+    pb,
+    pl,
+    pr,
+    pt,
+
+    height,
+    width,
+
+    maxHeight,
+    maxWidth,
+    minHeight,
+    minWidth,
+
+    // other
+    ...props
+  }: BoxProps,
+  ref: React.Ref<THREE.Group>
+) {
   // must memoize or the object literal will cause every dependent of flexProps to rerender everytime
   const flexProps: R3FlexProps = useMemo(() => {
     const _flexProps = {
@@ -228,10 +230,18 @@ export function Box({
   const sharedBoxContext = useMemo<SharedBoxContext>(() => ({ node, size, centerAnchor }), [node, size, centerAnchor])
 
   return (
-    <group ref={group} {...props}>
+    <group ref={mergeRefs([group, ref])} {...props}>
       <boxContext.Provider value={sharedBoxContext}>
         {typeof children === 'function' ? children(size[0], size[1], centerAnchor) : children}
       </boxContext.Provider>
     </group>
   )
 }
+
+/**
+ * Box container for 3D Objects.
+ * For containing Boxes use `<Flex />`.
+ */
+export const Box = React.forwardRef<THREE.Group, BoxProps>(BoxImpl)
+
+Box.displayName = 'Box'


### PR DESCRIPTION
This would with various helpers and hooks that use refs to somehow affect the component,
say rotate it or draw a bounding box
My use case is to draw a UI on a plane than rotate it towards the eyesight in vr

Any thoughts against it? One other thing is that because of the additional indent it looks like everthing has changed, but it's not. Maybe we want to extract a top level function we'll pass to React.forwardRef?