### PR TITLE
prevent readding boxes at the end of its parent

### DIFF
--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -192,17 +192,23 @@ export function Box({
     setYogaProperties(node, flexProps, scaleFactor)
   }, [flexProps, node, scaleFactor])
 
-  // Make child known to the parents yoga instance *before* it calculates layout
   useLayoutEffect(() => {
-    if (!group.current || !parent) return
-
-    parent.insertChild(node, parent.getChildCount())
-    registerBox(node, group.current, flexProps, centerAnchor)
+    if (!parent) return
 
     // Remove child on unmount
     return () => {
       parent.removeChild(node)
       unregisterBox(node)
+    }
+  }, [node, parent])
+
+  // Make child known to the parents yoga instance *before* it calculates layout
+  useLayoutEffect(() => {
+    if (!group.current || !parent) return
+
+    if (registerBox(node, group.current, flexProps, centerAnchor)) {
+      //newly registered node: add it to the parent
+      parent.insertChild(node, parent.getChildCount())
     }
   }, [node, parent, flexProps, centerAnchor, registerBox, unregisterBox])
 

--- a/src/Flex.tsx
+++ b/src/Flex.tsx
@@ -214,10 +214,16 @@ export function Flex({
   const registerBox = useCallback(
     (node: YogaNode, group: Group, flexProps: R3FlexProps, centerAnchor: boolean = false) => {
       const i = boxesRef.current.findIndex((b) => b.node === node)
+      const boxItem = { group, node, flexProps, centerAnchor }
       if (i !== -1) {
-        boxesRef.current.splice(i, 1)
+        //node already contained: update box
+        boxesRef.current[i] = boxItem
+        return false
+      } else {
+        //node not contained: insert new box
+        boxesRef.current.push(boxItem)
+        return true
       }
-      boxesRef.current.push({ group, node, flexProps, centerAnchor })
     },
     []
   )

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,7 +6,7 @@ import { R3FlexProps } from './props'
 export interface SharedFlexContext {
   scaleFactor: number
   requestReflow(): void
-  registerBox(node: YogaNode, group: Group, flexProps: R3FlexProps, centerAnchor?: boolean): void
+  registerBox(node: YogaNode, group: Group, flexProps: R3FlexProps, centerAnchor?: boolean): boolean
   unregisterBox(node: YogaNode): void
 }
 
@@ -17,6 +17,7 @@ const initialSharedFlexContext: SharedFlexContext = {
   },
   registerBox() {
     console.warn('Flex not initialized! Please report')
+    return false
   },
   unregisterBox() {
     console.warn('Flex not initialized! Please report')


### PR DESCRIPTION
registerBox now updates the existing boxesRef entry, instead of removing it and re-adding it. Also, the entry is not removed when the props change but only removed when the node or its parents change.

Fixes #16 