### PR TITLE
Added centerAcnhor prop on Flex, which centers it on position

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -155,3 +155,20 @@ export const getOBBSize = (object: Object3D, root: Object3D, bb: Box3, size: Vec
   object.matrixAutoUpdate = oldMatrixAutoUpdate
   root.updateMatrixWorld()
 }
+
+const getIsTopLevelChild = (node: YogaNode) => !node.getParent()?.getParent()
+
+/** @returns [mainAxisShift, crossAxisShift] */
+export const getRootShift = (
+  rootCenterAnchor: boolean | undefined,
+  rootWidth: number,
+  rootHeight: number,
+  node: YogaNode
+) => {
+  if (!rootCenterAnchor || !getIsTopLevelChild(node)) {
+    return [0, 0]
+  }
+  const mainAxisShift = -rootWidth / 2
+  const crossAxisShift = -rootHeight / 2
+  return [mainAxisShift, crossAxisShift] as const
+}


### PR DESCRIPTION
With centerAnchor={true} Flex starts behaving like a usual threejs element -
it centers itself on a position, rather than having this position as left-upper corner

Besides the fact that this easier to work with (now you don't have to do this manually via `-width / 2`),
the usecase is when you rotate the Flex to face the camera.
If you do it without the centerAnchor with `position={[-width/2, height/2]}`, rotation will behave like the center is shifted (when in fact, it's not)